### PR TITLE
Allow >1 gravity coordinates per imgproxy docs

### DIFF
--- a/src/Options/Gravity.php
+++ b/src/Options/Gravity.php
@@ -22,11 +22,11 @@ final class Gravity extends AbstractOption
     {
         $this->type = new GravityType($type);
 
-        if ($x < 0 || $x > 1) {
+        if ($x < 0) {
             throw new InvalidArgumentException(sprintf('Invalid gravity X: %s', $x));
         }
 
-        if ($y < 0 || $y > 1) {
+        if ($y < 0) {
             throw new InvalidArgumentException(sprintf('Invalid gravity Y: %s', $y));
         }
 

--- a/tests/Options/CropTest.php
+++ b/tests/Options/CropTest.php
@@ -62,6 +62,7 @@ class CropTest extends TestCase
             [100, 0, 'ce', 'c:100:0:ce'],
             [100, 200, 'ce', 'c:100:200:ce'],
             [100, 200, 'ce:0:0', 'c:100:200:ce:0:0'],
+            [100, 200, 'ce:200:250', 'c:100:200:ce:200:250'],
         ];
     }
 
@@ -85,8 +86,8 @@ class CropTest extends TestCase
             ['foo', 'Invalid gravity: foo'],
             ['ce:bar:0', 'Gravity X should be numeric'],
             ['ce:0:baz', 'Gravity Y should be numeric'],
-            ['ce:100:0', 'Invalid gravity X: 100'],
-            ['ce:0:500', 'Invalid gravity Y: 500'],
+            ['ce:-100:0', 'Invalid gravity X: -100'],
+            ['ce:0:-500', 'Invalid gravity Y: -500'],
         ];
     }
 }

--- a/tests/Options/ExtendAspectRatioTest.php
+++ b/tests/Options/ExtendAspectRatioTest.php
@@ -44,6 +44,7 @@ class ExtendAspectRatioTest extends TestCase
             [false, null, 'exar:0'],
             [true, 'ce', 'exar:1:ce'],
             [false, 'ce:0:0', 'exar:0:ce:0:0'],
+            [false, 'ce:200:250', 'exar:0:ce:200:250'],
         ];
     }
 
@@ -56,8 +57,8 @@ class ExtendAspectRatioTest extends TestCase
             ['foo', 'Invalid gravity: foo'],
             ['ce:bar:0', 'Gravity X should be numeric'],
             ['ce:0:baz', 'Gravity Y should be numeric'],
-            ['ce:100:0', 'Invalid gravity X: 100'],
-            ['ce:0:500', 'Invalid gravity Y: 500'],
+            ['ce:-100:0', 'Invalid gravity X: -100'],
+            ['ce:0:-500', 'Invalid gravity Y: -500'],
         ];
     }
 }

--- a/tests/Options/ExtendTest.php
+++ b/tests/Options/ExtendTest.php
@@ -44,6 +44,7 @@ class ExtendTest extends TestCase
             [false, null, 'ex:0'],
             [true, 'ce', 'ex:1:ce'],
             [false, 'ce:0:0', 'ex:0:ce:0:0'],
+            [false, 'ce:200:250', 'ex:0:ce:200:250'],
         ];
     }
 
@@ -56,8 +57,8 @@ class ExtendTest extends TestCase
             ['foo', 'Invalid gravity: foo'],
             ['ce:bar:0', 'Gravity X should be numeric'],
             ['ce:0:baz', 'Gravity Y should be numeric'],
-            ['ce:100:0', 'Invalid gravity X: 100'],
-            ['ce:0:500', 'Invalid gravity Y: 500'],
+            ['ce:-100:0', 'Invalid gravity X: -100'],
+            ['ce:0:-500', 'Invalid gravity Y: -500'],
         ];
     }
 }

--- a/tests/Options/GravityTest.php
+++ b/tests/Options/GravityTest.php
@@ -86,6 +86,7 @@ class GravityTest extends TestCase
             ['fp', 0.5, null, 'g:fp:0.5'],
             ['fp', null, 0.5, 'g:fp::0.5'],
             ['fp', 0.5, 0.7, 'g:fp:0.5:0.7'],
+            ['fp', 200, 250, 'g:fp:200:250'],
         ];
     }
 
@@ -99,6 +100,7 @@ class GravityTest extends TestCase
             ['ce:0.5', 'g:ce:0.5'],
             ['ce:0:0', 'g:ce:0:0'],
             ['ce:0.1:0.5', 'g:ce:0.1:0.5'],
+            ['ce:200:250', 'g:ce:200:250'],
         ];
     }
 
@@ -131,6 +133,7 @@ class GravityTest extends TestCase
     public function invalidGravityOffset(): array
     {
         return [
+            [-100],
             [-1],
             [-1.01],
         ];


### PR DESCRIPTION
Hey

[Imgproxy allows specifying absolute offsets for gravity](https://docs.imgproxy.net/usage/processing#gravity), while this library currently limits it to relative (0-1 floats) offsets only. This PR allows using absolute offsets.