### PR TITLE
Allow providing Gravity object directly

### DIFF
--- a/src/Options/Crop.php
+++ b/src/Options/Crop.php
@@ -10,14 +10,11 @@ final class Crop extends AbstractOption
     private Height $height;
     private ?Gravity $gravity = null;
 
-    public function __construct(int $width, int $height, ?string $gravity = null)
+    public function __construct(int $width, int $height, Gravity|string|null $gravity = null)
     {
         $this->width = new Width($width);
         $this->height = new Height($height);
-
-        if ($gravity !== null) {
-            $this->gravity = Gravity::fromString($gravity);
-        }
+        $this->gravity = is_string($gravity) ? Gravity::fromString($gravity) : $gravity;
     }
 
     /**

--- a/src/Options/Extend.php
+++ b/src/Options/Extend.php
@@ -9,13 +9,10 @@ final class Extend extends AbstractOption
     private bool $extend;
     private ?Gravity $gravity = null;
 
-    public function __construct(bool $extend = true, ?string $gravity = null)
+    public function __construct(bool $extend = true, Gravity|string|null $gravity = null)
     {
         $this->extend = $extend;
-
-        if ($gravity !== null) {
-            $this->gravity = Gravity::fromString($gravity);
-        }
+        $this->gravity = is_string($gravity) ? Gravity::fromString($gravity) : $gravity;
     }
 
     /**

--- a/tests/Options/CropTest.php
+++ b/tests/Options/CropTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Onliner\ImgProxy\Options;
 
+use Onliner\ImgProxy\Support\GravityType;
 use PHPUnit\Framework\TestCase;
 
 class CropTest extends TestCase
@@ -11,7 +12,7 @@ class CropTest extends TestCase
     /**
      * @dataProvider validData
      */
-    public function testCreate(int $width, int $height, ?string $gravity, string $expected): void
+    public function testCreate(int $width, int $height, Gravity|string|null $gravity, string $expected): void
     {
         $opt = new Crop($width, $height, $gravity);
         $this->assertSame($expected, (string) $opt);
@@ -61,8 +62,10 @@ class CropTest extends TestCase
             [100, 200, null, 'c:100:200'],
             [100, 0, 'ce', 'c:100:0:ce'],
             [100, 200, 'ce', 'c:100:200:ce'],
+            [100, 200, new Gravity(GravityType::CENTER), 'c:100:200:ce'],
             [100, 200, 'ce:0:0', 'c:100:200:ce:0:0'],
             [100, 200, 'ce:200:250', 'c:100:200:ce:200:250'],
+            [100, 200, new Gravity(GravityType::CENTER, 200, 250), 'c:100:200:ce:200:250'],
         ];
     }
 

--- a/tests/Options/ExtendTest.php
+++ b/tests/Options/ExtendTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Onliner\ImgProxy\Options;
 
+use Onliner\ImgProxy\Support\GravityType;
 use PHPUnit\Framework\TestCase;
 
 class ExtendTest extends TestCase
@@ -11,7 +12,7 @@ class ExtendTest extends TestCase
     /**
      * @dataProvider exampleData
      */
-    public function testCreate(bool $extend, ?string $gravity, string $expected): void
+    public function testCreate(bool $extend, Gravity|string|null $gravity, string $expected): void
     {
         $opt = new Extend($extend, $gravity);
 
@@ -45,8 +46,10 @@ class ExtendTest extends TestCase
             [true, null, 'ex:1'],
             [false, null, 'ex:0'],
             [true, 'ce', 'ex:1:ce'],
+            [true, new Gravity(GravityType::CENTER), 'ex:1:ce'],
             [false, 'ce:0:0', 'ex:0:ce:0:0'],
             [false, 'ce:200:250', 'ex:0:ce:200:250'],
+            [false, new Gravity(GravityType::CENTER, 200, 250), 'ex:0:ce:200:250'],
         ];
     }
 


### PR DESCRIPTION
Allows doing

```php
new Crop(
    $option->width,
    $option->height,
    new Gravity(GravityType::NORTH_WEST, $option->x, $option->y),
)
```

instead of

```php
new Crop(
    $option->width,
    $option->height,
    Str::after((string) new Gravity(GravityType::NORTH_WEST, $option->x, $option->y), 'g:'),
)
```

which is more readable and reliable.